### PR TITLE
Remove unneeded struct wrap

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,14 +23,12 @@ func init() {
 	}
 }
 
-type viewCount struct {
-	count int32
-}
+type viewCount int32
 
 var v viewCount
 
 func (n *viewCount) inc() (currentcount int32) {
-	return atomic.AddInt32(&n.count, 1)
+	return atomic.AddInt32((*int32)(n), 1)
 }
 
 func inc(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
If it's only the int32 in the struct you don't need the struct at all. This is what I was trying to do that evening but had the pointer cast syntax wrong.